### PR TITLE
Add ruby pipes

### DIFF
--- a/lua/pairs/init.lua
+++ b/lua/pairs/init.lua
@@ -21,6 +21,9 @@ local Pairs = {
       {"'", "'", {triplet = true}},
       {'"', '"', {triplet = true}},
     },
+    ruby = {
+      {'|', '|'},
+    },
     markdown = {
       {'`', '`', {triplet = true}},
     },


### PR DESCRIPTION
Ruby uses pipes to signify block params. Whenever you type one there is always a second one. 

```ruby
array.map do |element|
  element + 1
end

array.map { |element| element + 1 }
```