### PR TITLE
fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ Typeset right bracket
 
 ```
 press )
-|       --> |)       - type right
-|(ab)   --> |)(ab)   - type right
-(|      --> (|)      - complete right
+|       --> )|       - type right
+|(ab)   --> )|(ab)   - type right
+(|      --> ()|      - complete right
 (|)     --> ()|      - jump right when 'autojump_strategy.unbalanced' is not 'none'
 (| )    --> ()|      - jump right when 'autojump_strategy.unbalanced' is 'all' or 'loose_right'
 (a|b)   --> (ab)|    - jump right when 'autojump_strategy.unbalanced' is 'all'


### PR DESCRIPTION
Thanks for this great plugin.
It seems that the cursor position is wrong:
```
|       --> |)       - type right
|(ab)   --> |)(ab)   - type right
(|      --> (|)      - complete right
```
Should the cursor be to the right of the closing bracket?