### PR TITLE
Fix error when setup is called twice (e.g. by packer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ configurable.
 ***Note***: Only support bracket of single char (of multibyte). For multi-char pairs, see snippet
 plugins.
 
-***Note***: After `:PackerCompile`, you need to restart nvim to get the plugin work again.
-[Related issue](https://github.com/ZhiyuanLck/smart-pairs/issues/3).
-
 ## Configuration
 
 Setup the options by

--- a/lua/pairs/init.lua
+++ b/lua/pairs/init.lua
@@ -3,7 +3,7 @@ local u = require('pairs.utils')
 local fb = require('pairs.fallback')
 local push = table.insert
 
-local Pairs = {
+local state = {
   pairs = {
     ['*'] = {
       {'(', ')'},
@@ -184,11 +184,11 @@ local Pairs = {
   max_search_lines = 500,
 }
 
-Pairs.__index = Pairs
+local Pairs = {}
+setmetatable(Pairs, {__index=state})
 
 -- Pair
 local Pr = {}
-Pr.__index = Pr
 
 function Pr:new(pair)
   if type(pair) ~= 'table' then
@@ -282,7 +282,7 @@ function Pairs:setup(opts)
   self.lr, self.rl = {}, {}
   local new_pairs = {}
 
-  for ft, pairs in pairs(self.pairs) do
+  for ft, pairs in pairs(state.pairs) do
     new_pairs[ft] = {}
     self.lr[ft], self.rl[ft] = {}, {}
 

--- a/lua/pairs/init.lua
+++ b/lua/pairs/init.lua
@@ -3,7 +3,7 @@ local u = require('pairs.utils')
 local fb = require('pairs.fallback')
 local push = table.insert
 
-local state = {
+local config = {
   pairs = {
     ['*'] = {
       {'(', ')'},
@@ -185,7 +185,7 @@ local state = {
 }
 
 local Pairs = {}
-setmetatable(Pairs, {__index=state})
+setmetatable(Pairs, {__index=config})
 
 -- Pair
 local Pr = {}
@@ -282,7 +282,7 @@ function Pairs:setup(opts)
   self.lr, self.rl = {}, {}
   local new_pairs = {}
 
-  for ft, pairs in pairs(state.pairs) do
+  for ft, pairs in pairs(config.pairs) do
     new_pairs[ft] = {}
     self.lr[ft], self.rl[ft] = {}, {}
 


### PR DESCRIPTION
The issue was caused because Pairs.pairs was set in line 317
so when iterating over it in the second call to setup in line 286,
the pairs table will not be the same.

I fixed this by using a different table for the default options instead of Pairs.

---

(I also removed `Pr.__index = Pr` since I don't think that does anything)

Feel free to suggest a better name for `state`! 
This fixes #3 (you might want to reopen that issue so it will be properly closed by this PR).